### PR TITLE
Update camera screen to use new CameraValue API

### DIFF
--- a/lib/pages/camera_screen.dart
+++ b/lib/pages/camera_screen.dart
@@ -36,7 +36,7 @@ class CameraScreenState extends State<CameraScreen> {
 
   @override
   Widget build(BuildContext context) {
-    if (!controller.value.initialized) {
+    if (!controller.value.isInitialized) {
       return new Container();
     }
     return new AspectRatio(


### PR DESCRIPTION
"initialized" was changed to "isInitialized"

Updating it so people don't get confused by the error